### PR TITLE
Update mariadb.yml

### DIFF
--- a/composes-files/mariadb.yml
+++ b/composes-files/mariadb.yml
@@ -38,7 +38,7 @@ services:
       - MYSQL_PASSWORD=$DB_PASSWORD
       #- REMOTE_SQL=http://URL1/your.sql,https://URL2/your.sql
     healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      test: ["CMD", "mariadb-admin" ,"ping", "-h", "localhost"]
       timeout: 20s
       retries: 10
     labels:


### PR DESCRIPTION
Breaking change in latest version of MariaDB server utilities. They don't support mysql command prefix, just mariadb command prefix.

example: mysqladmin -> mariadb-admin